### PR TITLE
一旦ranking_mf96は使わないように変更

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -54,7 +54,7 @@ app.post("/submitScore", async (request, response) => {
   const qnumber: number = request.body.qnumber || 0
   const username: string = request.body.username || "Not working"
   const score: number = request.body.score || 0
-  await client.ranking_mf96.create({
+  await client.ranking.create({
     data: { problem: qnumber, username: username, score: score },
   })
   response.json()

--- a/frontend/src/pages/Result/index.tsx
+++ b/frontend/src/pages/Result/index.tsx
@@ -72,7 +72,7 @@ export default function Result() {
   // RankingをfetchAPIしてくる
   useEffect(() => {
     ;(async () => {
-      await fetch(`${import.meta.env.VITE_API_ENDPOINT}/fetchRankingMf96`, {
+      await fetch(`${import.meta.env.VITE_API_ENDPOINT}/fetchRanking`, {
         method: "post",
         headers: { "Content-Type": "application/json" },
       })


### PR DESCRIPTION
経緯
supabaseのproductionでprismaを使わずにranking_mf96のテーブルを作った結果、typing.utcode.netのほうで認識されなくなってしまった。おそらく、npx prisma dbpushをしていないから。
そのため、一旦ranking_mf96の機能をrankingテーブルで行うことにした。